### PR TITLE
Updating userObject for identify & track call

### DIFF
--- a/outbound.js
+++ b/outbound.js
@@ -1,13 +1,14 @@
 ;(function(exports){
     var D = function(a){function b(a){j(function(){throw a})}function c(b){return this.then(b,a)}function d(b){return this.then(a,b)}function e(b,c){return this.then(function(a){return k(b)?b.apply(null,l(a)?a:[a]):t.onlyFuncs?a:b},c||a)}function f(a){function b(){a()}return this.then(b,b),this}function g(a){return this.then(function(b){return k(a)?a.apply(null,l(b)?b.splice(0,0,void 0)&&b:[void 0,b]):t.onlyFuncs?b:a},function(b){return a(b)})}function h(c){return this.then(a,c?function(a){throw c(a),a}:b)}function i(a,b){var c=o(a);if(1===c.length&&l(c[0])){if(!c[0].length)return t.fulfilled([]);c=c[0]}var d=[],e=t(),f=c.length;if(f)for(var g=(function(a){c[a]=t.promisify(c[a]),c[a].then(function(g){a in d||(d[a]=b?c[a]:g,--f||e.resolve(d))},function(g){a in d||(b?(d[a]=c[a],--f||e.resolve(d)):e.reject(g))})}),h=0,i=f;i>h;h++)g(h);else e.resolve(d);return e.promise}var j,k=function(a){return"function"==typeof a},l=function(a){return Array.isArray?Array.isArray(a):a instanceof Array},m=function(a){return!(!a||!(typeof a).match(/function|object/))},n=function(b){return b===!1||b===a||null===b},o=function(a,b){return[].slice.call(a,b)},p="undefined",q=typeof TypeError===p?Error:TypeError;if(typeof process!==p&&process.nextTick)j=process.nextTick;else if(typeof MessageChannel!==p){var r=new MessageChannel,s=[];r.port1.onmessage=function(){s.length&&s.shift()()},j=function(a){s.push(a),r.port2.postMessage(0)}}else j=function(a){setTimeout(a,0)};var t=function(b){function i(){if(0!==s){var a,b=u,c=0,d=b.length,e=~s?0:1;for(u=[];d>c;c++)(a=b[c][e])&&a(p)}}function l(a){function b(a){return function(b){return c?void 0:(c=!0,a(b))}}var c=!1;if(s)return this;try{var d=m(a)&&a.then;if(k(d)){if(a===v)throw new q("Promise can't resolve itself");return d.call(a,b(l),b(o)),this}}catch(e){return b(o)(e),this}return r(function(){p=a,s=1,i()}),this}function o(a){return s||r(function(){try{throw a}catch(b){p=b}s=-1,i()}),this}var p,r=(a!==b?b:t.alwaysAsync)?j:function(a){a()},s=0,u=[],v={then:function(a,b){var c=t();return u.push([function(b){try{n(a)?c.resolve(b):c.resolve(k(a)?a(b):t.onlyFuncs?b:a)}catch(d){c.reject(d)}},function(a){if((n(b)||!k(b)&&t.onlyFuncs)&&c.reject(a),b)try{c.resolve(k(b)?b(a):b)}catch(d){c.reject(d)}}]),0!==s&&r(i),c.promise},success:c,error:d,otherwise:d,apply:e,spread:e,ensure:f,nodify:g,rethrow:h,isPending:function(){return!(0!==s)},getStatus:function(){return s}};return v.toSource=v.toString=v.valueOf=function(){return p===a?this:p},{promise:v,resolve:l,fulfill:l,reject:o}};t.deferred=t.defer=t,t.nextTick=j,t.alwaysAsync=!0,t.onlyFuncs=!0,t.resolved=t.fulfilled=function(a){return t(!0).resolve(a).promise},t.rejected=function(a){return t(!0).reject(a).promise},t.wait=function(a){var b=t();return setTimeout(b.resolve,a||0),b.promise},t.delay=function(a,b){var c=t();return setTimeout(function(){try{c.resolve(a.apply(null))}catch(b){c.reject(b)}},b||0),c.promise},t.promisify=function(a){return a&&k(a.then)?a:t.resolved(a)},t.all=function(){return i(arguments,!1)},t.resolveAll=function(){return i(arguments,!0)},t.nodeCapsule=function(a,b){return b||(b=a,a=void 0),function(){var c=t(),d=o(arguments);d.push(function(a,b){a?c.reject(a):c.resolve(arguments.length>2?o(arguments,1):b)});try{b.apply(a,d)}catch(e){c.reject(e)}return c.promise}};return t;}();
+    var _ = require('underscore');
 
     var BASE_URL = "https://api.outbound.io/v2";
     var VERSION = '0.3.0';
 
-    var APNS = "apns"
-    var GCM = "gcm"
+    var APNS = "apns";
+    var GCM = "gcm";
 
-    var API_KEY = ""
+    var API_KEY = "";
 
     function headers() {
         var client = 'Javascript';
@@ -28,51 +29,53 @@
         }
     }
 
-    function userObject(info, attributes) {
-        var data = {};
-        if (info && Object.prototype.toString.call(info) === '[object Object]') {
-            if (info.previousId && typeof info.previousId) {
-                data.previous_id = info.previousId;
-            }
-            if (info.groupId && typeof info.groupId) {
-                data.group_id = info.groupId;
-            }
-            if (info.groupAttributes && Object.prototype.toString.call(info.groupAttributes) === '[object Object]') {
-                data.group_attributes = info.groupAttributes;
-            }
-            if (info.firstName && typeof info.firstName) {
-                data.first_name = info.firstName;
-            }
-            if (info.lastName && typeof info.lastName) {
-                data.last_name = info.lastName;
-            }
-            if (info.email && typeof info.email) {
-                data.email = info.email;
-            }
-            if (info.phoneNumber && typeof info.phoneNumber) {
-                data.phone_number = info.phoneNumber;
-            }
-            if (info.apnsTokens) {
-                if (typeof info.apnsTokens === 'string') {
-                    info.apnsTokens = [info.apnsTokens];
-                }
-                if (Object.prototype.toString.call(info.apnsTokens) === '[object Array]') {
-                    data.apns = info.apnsTokens;
-                }
-            }
-            if (info.gcmTokens) {
-                if (typeof info.gcmTokens === 'string') {
-                    attributes.gcmTokens = [info.gcmTokens];
-                }
-                if (Object.prototype.toString.call(info.gcmTokens) === '[object Array]') {
-                    data.gcm = info.gcmTokens;
-                }
-            }
+    function userObject(info) {
+        if (!info) {
+          return;
         }
-        if (attributes && Object.prototype.toString.call(attributes) === '[object Object]') {
-            data.attributes = attributes;
+        // create a data object to store top level attributes
+        // only these properties can be sent in as top level
+        // everything else should be in attributes {} object
+        var data = {
+          first_name: info.firstName,
+          last_name: info.lastName,
+          email: info.email,
+          phone_number: info.phoneNumber,
+          group_id: info.groupId,
+          group_attributes: info.groupAttributes,
+          previous_id: info.previousId
+        };
+
+        // only add attributes if attributes exist
+        if (info.attributes) {
+          data.attributes = info.attributes;
         }
-        return data
+
+        // apns & gcm are each required as an array of strings
+        if (info.apnsTokens) {
+          if (typeof info.apnsTokens === 'string') {
+              info.apnsTokens = [info.apnsTokens];
+          }
+          if (Object.prototype.toString.call(info.apnsTokens) === '[object Array]') {
+              data.apns = info.apnsTokens;
+          }
+        }
+        if (info.gcmTokens) {
+          if (typeof info.gcmTokens === 'string') {
+              info.gcmTokens = [info.gcmTokens];
+          }
+          if (Object.prototype.toString.call(info.gcmTokens) === '[object Array]') {
+              data.gcm = info.gcmTokens;
+          }
+        }
+
+        // in order to send less useless data
+        // pick out all the undefined properties
+        data = _.pick(data, function(attribute){
+            return !_.isUndefined(attribute);
+        });
+
+        return data;
     }
 
     function post(endpoint, data, deferred) {
@@ -138,69 +141,61 @@
         API_KEY = thisApiKey;
     }
 
-    Outbound.prototype.identify = function(userId, info, attributes) {
+    Outbound.prototype.identify = function(userId, attributes) {
         var deferred = D();
 
         var typeofUserId = typeof userId;
         if (typeofUserId != "number" && typeofUserId != "string") {
             deferred.reject(error("Invalid user ID. Expected string or number, got " + typeofUserId, false));
         } else {
-            requestData = {"user_id": userId}
-
-            user = userObject(info, attributes)
+            requestData = {"user_id": userId};
+            user = userObject(attributes);
             for (var attr in user) {
                 requestData[attr] = user[attr];
             }
-
             post('/identify', requestData, deferred);
         }
         return deferred.promise;
-    }
+    };
 
-    Outbound.prototype.track = function(userId, event, properties, userInfo, userAttributes) {
+    Outbound.prototype.track = function(userId, event, properties, timestamp) {
         var deferred = D();
 
         var typeofUserId = typeof userId;
         var typeofEvent = typeof event;
         if (typeofUserId != "number" && typeofUserId != "string") {
             deferred.reject(error("Invalid user ID. Expected string or number, got " + typeofUserId, false));
-        } else  if (typeofEvent != "string") {
+        } else if (typeofEvent != "string") {
             deferred.reject(error("Invalid event. Expected string, got " + typeofEvent, false));
         } else {
-            requestData = {"user_id": userId, "properties": {}, "event": event}
-
-            user = userObject(userInfo, userAttributes)
-            for (var attr in user) {
-                if (!requestData.user) {
-                    requestData.user = {};
-                }
-                requestData.user[attr] = user[attr];
+            requestData = {"user_id": userId, "properties": {}, "event": event};
+            if (!timestamp){
+              requestData.timestamp = Math.floor(Date.now() / 1000);
             }
-
             if (properties && typeof properties === 'object') {
                 requestData.properties = properties;
             }
             post('/track', requestData, deferred);
         }
         return deferred.promise;
-    }
+    };
 
     Outbound.prototype.registerApnsToken = function(userId, token) {
         return deviceToken(APNS, true, userId, token);
-    }
+    };
 
     Outbound.prototype.registerGcmToken = function(userId, token) {
         return deviceToken(GCM, true, userId, token);
-    }
+    };
 
     Outbound.prototype.disableApnsToken = function(userId, token) {
         return deviceToken(APNS, false, userId, token);
-    }
+    };
 
     Outbound.prototype.disableGcmToken = function(userId, token) {
         return deviceToken(GCM, false, userId, token);
-    }
+    };
 
-    typeof window !== 'undefined' && (window.outbound = Outbound)
-    typeof module !== 'undefined' && module.exports && (module.exports = Outbound)
+    typeof window !== 'undefined' && (window.outbound = Outbound);
+    typeof module !== 'undefined' && module.exports && (module.exports = Outbound);
 })();

--- a/outbound.js
+++ b/outbound.js
@@ -203,6 +203,5 @@
         return deviceToken(GCM, false, userId, token);
     };
 
-    typeof window !== 'undefined' && (window.outbound = Outbound);
-    typeof module !== 'undefined' && module.exports && (module.exports = Outbound);
+    module.exports = Outbound;
 })();

--- a/outbound.js
+++ b/outbound.js
@@ -163,20 +163,27 @@
 
         var typeofUserId = typeof userId;
         var typeofEvent = typeof event;
+
         if (typeofUserId != "number" && typeofUserId != "string") {
             deferred.reject(error("Invalid user ID. Expected string or number, got " + typeofUserId, false));
         } else if (typeofEvent != "string") {
             deferred.reject(error("Invalid event. Expected string, got " + typeofEvent, false));
         } else {
             requestData = {"user_id": userId, "properties": {}, "event": event};
-            if (!timestamp){
-              requestData.timestamp = Math.floor(Date.now() / 1000);
+
+            if (timestamp){
+              requestData.time_stamp = timestamp;
+            } else {
+              requestData.time_stamp = Math.floor(Date.now() / 1000);
             }
+
             if (properties && typeof properties === 'object') {
                 requestData.properties = properties;
             }
+
             post('/track', requestData, deferred);
         }
+
         return deferred.promise;
     };
 

--- a/outbound.js
+++ b/outbound.js
@@ -3,7 +3,7 @@
     var _ = require('underscore');
 
     var BASE_URL = "https://api.outbound.io/v2";
-    var VERSION = '0.3.0';
+    var VERSION = '1.0.0';
 
     var APNS = "apns";
     var GCM = "gcm";

--- a/outbound.js
+++ b/outbound.js
@@ -172,9 +172,9 @@
             requestData = {"user_id": userId, "properties": {}, "event": event};
 
             if (timestamp){
-              requestData.time_stamp = timestamp;
+              requestData.timestamp = timestamp;
             } else {
-              requestData.time_stamp = Math.floor(Date.now() / 1000);
+              requestData.timestamp = Math.floor(Date.now() / 1000);
             }
 
             if (properties && typeof properties === 'object') {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,13 @@
   "bugs": {
     "url": "https://github.com/outboundio/lib-javascript/issues"
   },
+  "keywords": [
+    "outbound",
+    "messaging",
+    "analytics",
+    "node-outbound",
+    "outbound.io"
+  ],
   "homepage": "https://github.com/outboundio/lib-javascript",
   "dependencies": {
     "request": "~2.55.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git://github.com/outboundio/lib-javascript.git"
   },
-  "authors": "Travis Beauvais",
+  "contributors": ["Travis Beauvais", "Muhammad Usman <muhammad@usmanity.com> (http://usmanity.com)"],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/outboundio/lib-javascript/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outbound",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Outbound Javascript Library",
   "main": "outbound.js",
   "scripts": {
@@ -17,7 +17,8 @@
   },
   "homepage": "https://github.com/outboundio/lib-javascript",
   "dependencies": {
-    "request": "~2.36.0"
+    "request": "~2.55.0",
+    "underscore": "~1.8.3"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Moving to 1.0.0 so that all new changes are versioned properly and this will drop support for anything older than 1.0.0. 

- `time_stamp` is now an available parameter for `track` calls
- `userObject` has been rewritten, includes cleaning out `undefined` properties before sending data
- Adding `underscore`
- Updating `request` from `2.36.0` to `2.55.0`
- adding a bunch of missing semi-colons coz of OCD
- removing `userAttributes` from `track` call